### PR TITLE
Potential fix for code scanning alert no. 51: Template Object Injection

### DIFF
--- a/routes/dataErasure.ts
+++ b/routes/dataErasure.ts
@@ -70,7 +70,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       const isForbiddenFile: boolean = (filePath.includes('ftp') || filePath.includes('ctf.key') || filePath.includes('encryptionkeys'))
       if (!isForbiddenFile) {
         res.render('dataErasureResult', {
-          ...req.body
+          email: req.body.email,
+          securityAnswer: req.body.securityAnswer
         }, (error, html) => {
           if (!html || error) {
             next(new Error(error.message))
@@ -85,7 +86,8 @@ router.post('/', async (req: Request<Record<string, unknown>, Record<string, unk
       }
     } else {
       res.render('dataErasureResult', {
-        ...req.body
+        email: req.body.email,
+        securityAnswer: req.body.securityAnswer
       })
     }
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/armindoarruty/juice-shop-ada-1497/security/code-scanning/51](https://github.com/armindoarruty/juice-shop-ada-1497/security/code-scanning/51)

The best way to fix this issue is to prevent user-controlled objects, like `req.body`, from being passed wholesale to the template engine. Instead, only explicitly define and pass the properties required by the template. In this handler, that means constructing a new object with just the fields you expect the template to use (`email` and `securityAnswer` according to the `DataErasureRequestParams` interface). This can be done by picking those properties from `req.body` and passing only those to `res.render()`. You will need to make this change in both code paths where `res.render('dataErasureResult', {...req.body})` is called (lines 73 and 88). This does not change existing functionality, as long as the template does not rely on unknown properties (which it should not for security). No new imports are required for this, just update the object construction in the appropriate places.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
