### PR TITLE
Potential fix for code scanning alert no. 64: Type confusion through parameter tampering

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -133,6 +133,9 @@ export const redirectAllowlist = new Set([
 ])
 
 export const isRedirectAllowed = (url: string) => {
+  if (typeof url !== 'string') {
+    return false
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge


### PR DESCRIPTION
Potential fix for [https://github.com/armindoarruty/juice-shop-ada-1497/security/code-scanning/64](https://github.com/armindoarruty/juice-shop-ada-1497/security/code-scanning/64)

To fix the issue, we must ensure that the input parameter to `isRedirectAllowed` is of type string before using string methods. The recommended pattern is to add a runtime type check at the start of `isRedirectAllowed` and reject/return false for any non-string input. This can be accomplished by verifying `typeof url === "string"` and, if not, returning `false`. This should be implemented in `lib/insecurity.ts`, at the start of the `isRedirectAllowed` function. There are no imports or helper methods required; only the body of this function needs a small modification. No other adjacent code needs editing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
