### PR TITLE
Potential fix for code scanning alert no. 65: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -19,6 +19,10 @@ class ErrorWithParent extends Error {
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    if (typeof criteria !== 'string') {
+      res.status(400).send('Bad request')
+      return
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/armindoarruty/juice-shop-ada-1497/security/code-scanning/65](https://github.com/armindoarruty/juice-shop-ada-1497/security/code-scanning/65)

To fix this problem, the runtime type of the untrusted request parameter should be explicitly checked before performing any string-specific operations on it. In particular, before using `.length`, `.substring`, and inserting the value into a SQL query, verify that `criteria` is a string. If it is not a string (i.e., is an array or any other type), reject the request as bad. The best fix is to modify the block where `criteria` is set from `req.query.q` and add a check: if it is not a string, return a `400 Bad Request` response. This check should happen immediately after `criteria` is set. The rejection should be early, and, if possible, before any further logic is applied so as not to modify existing functionality. No new methods are needed; just an extra type check and error response in the function closure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
